### PR TITLE
build: remove assets from semantic-release/github config

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -6,7 +6,7 @@ module.exports = {
     '@semantic-release/github',
     [
       {
-        assets: ['CHANGELOG.md', 'package.json'],
+        assets: [],
         message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
       }
     ]


### PR DESCRIPTION
Still not sure what the `assets` section of this does.